### PR TITLE
Miscellaneous Fixes 

### DIFF
--- a/LabApi/Features/Permissions/PermissionsExtensions.cs
+++ b/LabApi/Features/Permissions/PermissionsExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using CommandSystem;
 using LabApi.Features.Wrappers;
+using RemoteAdmin;
 
 namespace LabApi.Features.Permissions;
 
@@ -20,11 +21,11 @@ public static class PermissionsExtensions
 
     /// <inheritdoc cref="IPermissionsProvider.HasPermissions"/>
     public static bool HasPermissions(this ICommandSender sender, params string[] permissions) =>
-        Player.Get(sender)?.HasPermissions(permissions) ?? false;
+        Player.Get(sender)?.HasPermissions(permissions) ?? sender is not PlayerCommandSender;
 
     /// <inheritdoc cref="IPermissionsProvider.HasAnyPermission"/>
     public static bool HasAnyPermission(this ICommandSender sender, params string[] permissions) =>
-        Player.Get(sender)?.HasAnyPermission(permissions) ?? false;
+        Player.Get(sender)?.HasAnyPermission(permissions) ?? sender is not PlayerCommandSender;
 
     /// <inheritdoc cref="IPermissionsProvider.AddPermissions"/>
     public static void AddPermissions(this ICommandSender sender, params string[] permissions) =>

--- a/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
+++ b/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
@@ -174,7 +174,7 @@ public class DefaultPermissionsProvider : IPermissionsProvider
                     break;
                 }
             
-                if (!permission.Contains("."))
+                if (!permission.Contains(".*"))
                     continue;
 
                 int index = permission.LastIndexOf(".", StringComparison.Ordinal);

--- a/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
+++ b/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
@@ -171,7 +171,7 @@ public class DefaultPermissionsProvider : IPermissionsProvider
                 {
                     permissionsGroup.IsRoot = true;
                     // We don't have to continue.
-                    return;
+                    break;
                 }
             
                 if (!permission.Contains("."))

--- a/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
+++ b/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
@@ -167,7 +167,7 @@ public class DefaultPermissionsProvider : IPermissionsProvider
             permissionsGroup.SpecialPermissionsSuperset.Clear();
             foreach (string permission in permissionsGroup.Permissions)
             {
-                if (permission == "*")
+                if (permission == ".*")
                 {
                     permissionsGroup.IsRoot = true;
                     // We don't have to continue.

--- a/LabApi/Features/Wrappers/Players/Player.cs
+++ b/LabApi/Features/Wrappers/Players/Player.cs
@@ -1169,7 +1169,7 @@ public class Player
     public List<Pickup> DropAllItems()
     {
         List<Pickup> items = ListPool<Pickup>.Shared.Rent();
-        foreach (Item item in Items)
+        foreach (Item item in Items.ToArray())
             items.Add(DropItem(item));
 
         return items;
@@ -1221,7 +1221,7 @@ public class Player
     /// </summary>
     public void ClearItems()
     {
-        foreach (Item item in Items)
+        foreach (Item item in Items.ToArray())
             RemoveItem(item);
     }
 

--- a/LabApi/Features/Wrappers/Players/Player.cs
+++ b/LabApi/Features/Wrappers/Players/Player.cs
@@ -463,7 +463,7 @@ public class Player
     /// <summary>
     /// Gets the <see cref="Item">items</see> in the player's inventory.
     /// </summary>
-    public IEnumerable<Item?> Items => Inventory.UserInventory.Items.Values.Select(Item.Get);
+    public IEnumerable<Item> Items => Inventory.UserInventory.Items.Values.Select(Item.Get)!;
 
     /// <summary>
     /// Gets the player's Reserve Ammo.


### PR DESCRIPTION
## Changes
- `Player#DropAllItems` no longer throws an InvalidOperationException
- `Player#ClearItems` no longer throws an InvalidOperationException
- `Player#Items` no longer returns an Enumerable of nullable Items - as ItemBase itself is not null in InventoryInfo
   - Setting a groups permission to just `*` would previously throw an error
   - Using "\*" or '\*' would not work as it would interpret the entire string
- `DefaultPermissionsProvider` now uses `.*` for root permission
- `DefaultPermissionsProvider` `ReloadPermissions` now breaks out of the current for-loop instead of returning early out of the entire method
- `PermissionsExtensions` now allows the server-console to run commands