### PR TITLE
Add CustomDataStore.Exists, alongside helper method on Player

### DIFF
--- a/LabApi/Features/Stores/CustomDataStore.cs
+++ b/LabApi/Features/Stores/CustomDataStore.cs
@@ -58,6 +58,23 @@ public abstract class CustomDataStore
     }
 
     /// <summary>
+    /// Checks if the <see cref="CustomDataStore"/> for the specified <see cref="Player"/> exists.
+    /// </summary>
+    /// <param name="player"> The <see cref="Player"/> to check the <see cref="CustomDataStore"/> for.</param>
+    /// <typeparam name="TStore">The type of the <see cref="CustomDataStore"/></typeparam>
+    /// <returns>True if the <see cref="CustomDataStore"/> exists for the specified <see cref="Player"/>, false if not.</returns>
+    public static bool Exists<TStore>(Player player)
+        where TStore : CustomDataStore
+    {
+        Type type = typeof(TStore);
+
+        if (!StoreInstances.TryGetValue(type, out Dictionary<Player, CustomDataStore>? playerStores))
+            return false;
+
+        return playerStores.ContainsKey(player);
+    }
+
+    /// <summary>
     /// Called when a new instance of the <see cref="CustomDataStore"/> is created.
     /// </summary>
     protected virtual void OnInstanceCreated() { }
@@ -133,4 +150,12 @@ public abstract class CustomDataStore<TStore> : CustomDataStore
     /// <param name="player">The <see cref="Player"/> to get the <see cref="CustomDataStore"/> for.</param>
     /// <returns>The <see cref="CustomDataStore"/> for the specified <see cref="Player"/>.</returns>
     public static TStore Get(Player player) => GetOrAdd<TStore>(player);
+
+    /// <summary>
+    /// Checks if the <see cref="CustomDataStore"/> for the specified <see cref="Player"/> exists.
+    /// </summary>
+    /// <param name="player"> The <see cref="Player"/> to check the <see cref="CustomDataStore"/> for.</param>
+    /// <typeparam name="TStore">The type of the <see cref="CustomDataStore"/></typeparam>
+    /// <returns>True if the <see cref="CustomDataStore"/> exists for the specified <see cref="Player"/>, false if not.</returns>
+    public static bool Exists(Player player) => Exists<TStore>(player);
 }

--- a/LabApi/Features/Wrappers/Players/Player.cs
+++ b/LabApi/Features/Wrappers/Players/Player.cs
@@ -1505,6 +1505,17 @@ public class Player
     }
 
     /// <summary>
+    /// Checks if the <see cref="CustomDataStore"/> exists on the player.
+    /// </summary>
+    /// <typeparam name="TStore">The type of the <see cref="CustomDataStore"/></typeparam>
+    /// <returns>True if the <see cref="CustomDataStore"/> exists on the player, false if not.</returns>
+    public bool HasDataStore<TStore>()
+        where TStore : CustomDataStore
+    {
+        return CustomDataStore.Exists<TStore>(this);
+    }
+
+    /// <summary>
     /// Handles the creation of a player in the server.
     /// </summary>
     /// <param name="referenceHub">The reference hub of the player.</param>


### PR DESCRIPTION
This PR adds `CustomDataStore.Exists()`, which allows you to check if a `CustomDataStore` instance exists on the given `Player`, without creating one like `CustomDataStore.GetOrAdd()` would.

Since there currently is no way to check for that, I figured I'd make a PR. 

It also adds `CustomDataStore<TStore>.Exists()` and `Player.HasDataStore<TStore>()` as helper methods.