### PR TITLE
Add CustomDataStore.Exists, alongside helper method on Player

### DIFF
--- a/LabApi/Features/Stores/CustomDataStore.cs
+++ b/LabApi/Features/Stores/CustomDataStore.cs
@@ -55,6 +55,23 @@ public abstract class CustomDataStore
     }
     
     /// <summary>
+    /// Checks if the <see cref="CustomDataStore"/> for the specified <see cref="Player"/> exists.
+    /// </summary>
+    /// <param name="player"> The <see cref="Player"/> to check the <see cref="CustomDataStore"/> for.</param>
+    /// <typeparam name="TStore">The type of the <see cref="CustomDataStore"/></typeparam>
+    /// <returns>True if the <see cref="CustomDataStore"/> exists for the specified <see cref="Player"/>, false if not.</returns>
+    public static bool Exists<TStore>(Player player)
+        where TStore : CustomDataStore
+    {
+        Type type = typeof(TStore);
+
+        if (!StoreInstances.TryGetValue(type, out Dictionary<Player, CustomDataStore>? playerStores))
+            return false;
+
+        return playerStores.ContainsKey(player);
+    }
+    
+    /// <summary>
     /// Gets all instances of the <see cref="CustomDataStore"/> for the specified type.
     /// </summary>
     /// <typeparam name="TStore">The type of the <see cref="CustomDataStore"/>.</typeparam>
@@ -143,4 +160,7 @@ public abstract class CustomDataStore<TStore> : CustomDataStore
     
     /// <inheritdoc cref="CustomDataStore.GetAll{TStore}"/>
     public static IEnumerable<(Player Player, TStore Store)> GetAll() => CustomDataStore.GetAll<TStore>();
+    
+    /// <inheritdoc cref="CustomDataStore.Exists{TStore}"/>
+    public static bool Exists(Player player) => Exists<TStore>(player);
 }

--- a/LabApi/Features/Wrappers/Players/Player.cs
+++ b/LabApi/Features/Wrappers/Players/Player.cs
@@ -1503,6 +1503,17 @@ public class Player
     {
         return CustomDataStore.GetOrAdd<TStore>(this);
     }
+    
+    /// <summary>
+    /// Checks if the <see cref="CustomDataStore"/> exists on the player.
+    /// </summary>
+    /// <typeparam name="TStore">The type of the <see cref="CustomDataStore"/></typeparam>
+    /// <returns>True if the <see cref="CustomDataStore"/> exists on the player, false if not.</returns>
+    public bool HasDataStore<TStore>()
+        where TStore : CustomDataStore
+    {
+        return CustomDataStore.Exists<TStore>(this);
+    }
 
     /// <summary>
     /// Handles the creation of a player in the server.


### PR DESCRIPTION
This PR adds `CustomDataStore.Exists()`, which allows you to check if a `CustomDataStore` instance exists on the given `Player`, without creating one like `CustomDataStore.GetOrAdd()` would.

Since there currently is no way to check for that, I figured I'd make a PR. 

It also adds `CustomDataStore<TStore>.Exists()` and `Player.HasDataStore<TStore>()` as helper methods.

Made a new PR to merge into `data-store-performance` instead of `master` as requested by @x3rt 