### PR TITLE
Fix: Load Config before commands

### DIFF
--- a/LabApi/Loader/PluginLoader.cs
+++ b/LabApi/Loader/PluginLoader.cs
@@ -258,11 +258,11 @@ public static partial class PluginLoader
             // We mark the server as modded.
             CustomNetworkManager.Modded = true;
             
-            // We register all the plugin commands
-            plugin.RegisterCommands();
-
             // We load the configurations of the plugin
             plugin.LoadConfigs();
+            
+            // We register all the plugin commands
+            plugin.RegisterCommands();
 
             // We enable the plugin if it is not disabled
             plugin.Enable();


### PR DESCRIPTION
Actually, the config is loaded after the commands. This was an issue for plugins that have configurable commands