### PR TITLE
Make Player.GameObject nullable and null check ReferenceHub before accessing it.

### DIFF
--- a/LabApi/Features/Wrappers/Players/Player.cs
+++ b/LabApi/Features/Wrappers/Players/Player.cs
@@ -142,7 +142,7 @@ public class Player
     /// <summary>
     /// Gets the player's <see cref="GameObject"/>.
     /// </summary>
-    public GameObject GameObject => ReferenceHub.gameObject;
+    public GameObject? GameObject => ReferenceHub?.gameObject;
 
     /// <summary>
     /// Gets whether the player is the host or server.


### PR DESCRIPTION
Considering `ReferenceHub` can be null/destroyed, this would avoid exceptions just from accessing `Player.GameObject` while it's not valid.