### PR TITLE
feat: player sides

### DIFF
--- a/LabApi/Features/Enums/Side.cs
+++ b/LabApi/Features/Enums/Side.cs
@@ -1,0 +1,29 @@
+﻿namespace LabApi.Features.Enums
+{
+    /// <summary>
+    /// Enum type that represents a side, useful for seeing if someone can harm another person when comparing these together.
+    /// </summary>
+    public enum Side
+    {
+        /// <summary>
+        /// The person's side is part of the Foundation. i.e. Scientists, Facility guards and the MTF force.
+        /// </summary>
+        Foundation,
+        /// <summary>
+        /// The person's side is part of the Chaos Insurgency. i.e. Class-D and the Chaos force.
+        /// </summary>
+        Chaos,
+        /// <summary>
+        /// The person's side is SCPs. This includes all SCPs.
+        /// </summary>
+        Scp,
+        /// <summary>
+        /// The person is a tutorial.
+        /// </summary>
+        Tutorial,
+        /// <summary>
+        /// The person has an unknown side.
+        /// </summary>
+        None
+    }
+}

--- a/LabApi/Features/Wrappers/Players/Player.cs
+++ b/LabApi/Features/Wrappers/Players/Player.cs
@@ -678,6 +678,17 @@ public class Player
     public Team Team => RoleBase.Team;
 
     /// <summary>
+    /// Gets the player's current <see cref="Side"/>.
+    /// </summary>
+    public Side Side => Team switch
+    {
+        Team.SCPs => Side.Scp,
+        Team.ChaosInsurgency or Team.ClassD => Side.Chaos,
+        Team.FoundationForces or Team.Scientists => Side.Foundation,
+        _ => Role == RoleTypeId.Tutorial ? Side.Tutorial : Side.None
+    };
+
+    /// <summary>
     /// Gets whether the player is currently Alive.
     /// </summary>
     public bool IsAlive => Team != Team.Dead;


### PR DESCRIPTION
Simple, just adds a `Side` property to player that allows people to easily tell if people are on the same side, i.e. can't attack each other if FF is off.