### PR TITLE
IsAbstract plugin check + separate embedded dependency resolving pass

### DIFF
--- a/LabApi/Loader/Features/Misc/AssemblyUtils.cs
+++ b/LabApi/Loader/Features/Misc/AssemblyUtils.cs
@@ -120,6 +120,7 @@ public static class AssemblyUtils
     {
         if (!TryGetDataStream(target, name, out Stream? dataStream))
             return;
+
         string path = Path.GetTempFileName();
         using (FileStream file = File.Create(path))
         {
@@ -181,7 +182,6 @@ public static class AssemblyUtils
     }
 
     // Used for missing assembly comparisons.
-
     private static string FormatAssemblyName(AssemblyName assemblyName) => $"{assemblyName.Name} v{assemblyName.Version}";
 
     private static void LoadAssemblyIfMissing(string path)

--- a/LabApi/Loader/Features/Misc/AssemblyUtils.cs
+++ b/LabApi/Loader/Features/Misc/AssemblyUtils.cs
@@ -192,7 +192,7 @@ public static class AssemblyUtils
             // only check name to avoid identity problems
             if (name != null && AppDomain.CurrentDomain.GetAssemblies().All(e => e.GetName().Name != name.Name))
             {
-                Assembly.Load(File.ReadAllBytes(path));
+                PluginLoader.Dependencies.Add(Assembly.Load(File.ReadAllBytes(path)));
             }
         }
         finally

--- a/LabApi/Loader/Features/Misc/AssemblyUtils.cs
+++ b/LabApi/Loader/Features/Misc/AssemblyUtils.cs
@@ -66,7 +66,7 @@ public static class AssemblyUtils
     {
         return AppDomain.CurrentDomain.GetAssemblies().Select(NameSelector);
         // We will use this selector to format the assembly names to the format we want.
-        string NameSelector(Assembly assembly) => FormatAssemblyName(assembly.GetName());
+        static string NameSelector(Assembly assembly) => FormatAssemblyName(assembly.GetName());
     }
 
     /// <summary>
@@ -107,23 +107,6 @@ public static class AssemblyUtils
                 // If the resource is a compressed dll, we load it as a compressed embedded dll.
                 LoadCompressedEmbeddedDll(assembly, resourceName);
             }
-        }
-    }
-    
-    private static void LoadAssemblyIfMissing(string path)
-    {
-        try
-        {
-            AssemblyName? name = AssemblyName.GetAssemblyName(path);
-            // only check name to avoid identity problems
-            if (name != null && AppDomain.CurrentDomain.GetAssemblies().All(e => e.GetName().Name != name.Name))
-            {
-                Assembly.Load(File.ReadAllBytes(path));
-            }
-        }
-        finally
-        {
-            File.Delete(path);
         }
     }
 
@@ -198,5 +181,23 @@ public static class AssemblyUtils
     }
 
     // Used for missing assembly comparisons.
+
     private static string FormatAssemblyName(AssemblyName assemblyName) => $"{assemblyName.Name} v{assemblyName.Version}";
+
+    private static void LoadAssemblyIfMissing(string path)
+    {
+        try
+        {
+            AssemblyName? name = AssemblyName.GetAssemblyName(path);
+            // only check name to avoid identity problems
+            if (name != null && AppDomain.CurrentDomain.GetAssemblies().All(e => e.GetName().Name != name.Name))
+            {
+                Assembly.Load(File.ReadAllBytes(path));
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
 }

--- a/LabApi/Loader/Features/Misc/AssemblyUtils.cs
+++ b/LabApi/Loader/Features/Misc/AssemblyUtils.cs
@@ -76,7 +76,7 @@ public static class AssemblyUtils
     /// <returns>A formatted <see cref="IEnumerable{T}"/> with the missing dependencies.</returns>
     public static IEnumerable<string> GetMissingDependencies(Assembly assembly)
     {
-        IEnumerable<string> loadedAssemblies = GetLoadedAssemblies();
+        HashSet<string> loadedAssemblies = GetLoadedAssemblies().ToHashSet();
         // Using the same format, we will get the missing dependencies.
         return assembly.GetReferencedAssemblies().Select(FormatAssemblyName).Where(name => !loadedAssemblies.Contains(name));
     }
@@ -85,6 +85,7 @@ public static class AssemblyUtils
     /// Resolves embedded resources from the specified <see cref="Assembly"/>.
     /// </summary>
     /// <param name="assembly">The assembly to resolve embedded resources from.</param>
+    /// <remarks>This method loads each DLL if no such assembly with the same name has been loaded into the current AppDomain yet.</remarks>
     public static void ResolveEmbeddedResources(Assembly assembly)
     {
         const string dllExtension = ".dll";
@@ -108,41 +109,59 @@ public static class AssemblyUtils
             }
         }
     }
-
-    /// <summary>
-    /// Loads an embedded dll from the specified <see cref="Assembly"/>.
-    /// </summary>
-    /// <param name="target">The assembly to load the embedded dll from.</param>
-    /// <param name="name">The resource name of the embedded dll.</param>
-    public static void LoadEmbeddedDll(Assembly target, string name)
+    
+    private static void LoadAssemblyIfMissing(string path)
     {
-        // We try to get the data stream of the specified resource name.
-        if (!TryGetDataStream(target, name, out Stream? dataStream))
-            return;
-
-        // We copy the data stream to a memory stream and load the assembly from the memory stream.
-        using MemoryStream stream = new();
-        dataStream.CopyTo(stream);
-        Assembly.Load(stream.ToArray());
+        try
+        {
+            AssemblyName? name = AssemblyName.GetAssemblyName(path);
+            // only check name to avoid identity problems
+            if (name != null && AppDomain.CurrentDomain.GetAssemblies().All(e => e.GetName().Name != name.Name))
+            {
+                Assembly.Load(File.ReadAllBytes(path));
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     /// <summary>
-    /// Loads a compressed embedded dll from the specified <see cref="Assembly"/>.
+    /// Loads an embedded dll from the specified <see cref="Assembly"/> if no such assembly with the same name has been loaded.
+    /// </summary>
+    /// <param name="target">The assembly to load the embedded dll from.</param>
+    /// <param name="name">The resource name of the embedded dll.</param>
+    /// <remarks>The name check only checks for the <see cref="AssemblyName.Name"/> of the <see cref="AssemblyName"/>.</remarks>
+    public static void LoadEmbeddedDll(Assembly target, string name)
+    {
+        if (!TryGetDataStream(target, name, out Stream? dataStream))
+            return;
+        string path = Path.GetTempFileName();
+        using (FileStream file = File.Create(path))
+        {
+            dataStream.CopyTo(file);
+        }
+        LoadAssemblyIfMissing(path);
+    }
+
+    /// <summary>
+    /// Loads a compressed embedded dll from the specified <see cref="Assembly"/> if no such assembly with the same name has been loaded.
     /// </summary>
     /// <param name="target">The assembly to load the compressed embedded dll from.</param>
     /// <param name="name">The resource name of the compressed embedded dll.</param>
+    /// <remarks>The name check only checks for the <see cref="AssemblyName.Name"/> of the <see cref="AssemblyName"/>.</remarks>
     public static void LoadCompressedEmbeddedDll(Assembly target, string name)
     {
-        // We try to get the data stream of the specified resource name.
         if (!TryGetDataStream(target, name, out Stream? dataStream))
             return;
-
-        // We decompress the data stream and load the assembly from the memory stream.
-        using DeflateStream stream = new(dataStream, CompressionMode.Decompress);
-        // We use a memory stream to load the assembly from the decompressed data stream.
-        using MemoryStream memStream = new();
-        stream.CopyTo(memStream);
-        Assembly.Load(memStream.ToArray());
+        string path = Path.GetTempFileName();
+        using (DeflateStream stream = new(dataStream, CompressionMode.Decompress))
+        using (FileStream file = File.Create(path))
+        {
+            stream.CopyTo(file);
+        }
+        LoadAssemblyIfMissing(path);
     }
 
     /// <summary>

--- a/LabApi/Loader/PluginLoader.cs
+++ b/LabApi/Loader/PluginLoader.cs
@@ -215,36 +215,6 @@ public static partial class PluginLoader
         }
     }
 
-    private static void LogMissingDependencies(Assembly assembly)
-    {
-        string[] missing = AssemblyUtils.GetMissingDependencies(assembly).ToArray();
-        if (missing.Length != 0)
-        {
-            Logger.Error($"{LoggerPrefix} Missing dependencies:\n{string.Join("\n", missing.Select(x => $"-\t {x}"))}");
-        }
-    }
-
-    private static void InstantiatePlugins(Type[] types, Assembly assembly, string filePath)
-    {
-        foreach (Type type in types)
-        {
-            // We check if the type is derived from Plugin.
-            if (!type.IsSubclassOf(typeof(Plugin)) || type.IsAbstract)
-                continue;
-
-            // We create an instance of the type and check if it was successfully created.
-            if (Activator.CreateInstance(type) is not Plugin plugin)
-                continue;
-
-            // Set the file path
-            plugin.FilePath = filePath;
-
-            // In that case, we add the plugin to the plugins list and log that it has been loaded.
-            Plugins.Add(plugin, assembly);
-            Logger.Info($"{LoggerPrefix} Successfully loaded {plugin.Name}");
-        }
-    }
-
     /// <summary>
     /// Enables a collection of <see cref="Plugin"/>s.
     /// </summary>
@@ -329,5 +299,35 @@ public static partial class PluginLoader
     private static string ResolvePath(string path)
     {
         return path.Replace("$port", Server.Port.ToString());
+    }
+
+    private static void LogMissingDependencies(Assembly assembly)
+    {
+        IEnumerable<string> missing = AssemblyUtils.GetMissingDependencies(assembly);
+        if (missing.Any())
+        {
+            Logger.Error($"{LoggerPrefix} Missing dependencies:\n{string.Join("\n", missing.Select(static x => $"-\t {x}"))}");
+        }
+    }
+
+    private static void InstantiatePlugins(Type[] types, Assembly assembly, string filePath)
+    {
+        foreach (Type type in types)
+        {
+            // We check if the type is derived from Plugin.
+            if (!type.IsSubclassOf(typeof(Plugin)) || type.IsAbstract)
+                continue;
+
+            // We create an instance of the type and check if it was successfully created.
+            if (Activator.CreateInstance(type) is not Plugin plugin)
+                continue;
+
+            // Set the file path
+            plugin.FilePath = filePath;
+
+            // In that case, we add the plugin to the plugins list and log that it has been loaded.
+            Plugins.Add(plugin, assembly);
+            Logger.Info($"{LoggerPrefix} Successfully loaded {plugin.Name}");
+        }
     }
 }

--- a/LabApi/Loader/PluginLoader.cs
+++ b/LabApi/Loader/PluginLoader.cs
@@ -194,7 +194,7 @@ public static partial class PluginLoader
             }
             catch (Exception e)
             {
-                Logger.Error($"{LoggerPrefix} Couldn't load the assembly inside '{path}'");
+                Logger.Error($"{LoggerPrefix} Failed to resolve embedded resources for assembly '{path}'");
                 LogMissingDependencies(assembly);
                 Logger.Error(e);
             }

--- a/LabApi/Loader/PluginLoader.cs
+++ b/LabApi/Loader/PluginLoader.cs
@@ -210,7 +210,7 @@ public static partial class PluginLoader
         foreach (Type type in types)
         {
             // We check if the type is derived from Plugin.
-            if (!type.IsSubclassOf(typeof(Plugin)))
+            if (!type.IsSubclassOf(typeof(Plugin)) || type.IsAbstract)
                 continue;
 
             // We create an instance of the type and check if it was successfully created.


### PR DESCRIPTION
This PR allows the definition of abstract plugin types, and fixes the scenario where a plugin's embedded DLLs would be loaded after another dependent plugin attempted enabling.

- Plugin assemblies can now define abstract plugin types, allowing them to be inherited
- Created a separate pass for dependency resolving (relates to #9)

# The current dependency problem:

**Assume the following scenario:**

The following plugins are to be loaded:

- PluginA
- PluginB
- PluginC

Both `PluginA` and `PluginC` depend on an external dependency `Dependency`
`PluginB` includes `Dependency` as an embedded resource.

1. `PluginA`'s assembly is loaded.
2. The loader attempts to initialize `PluginA`, but might fail because `Dependency` is not loaded, unless if `Dependency` included separately in LabAPI's `dependencies` folder.
3. `PluginB`'s assembly is loaded, `Dependency` is extracted, `PluginB` loads.
4. `PluginC`'s assembly is loaded, the plugin is initialized without issues.

Failure also occurs if `PluginB` does not have missing dependencies (e.g. it does not depend on `Dependency` while including it as embedded) but `PluginC` depends on `Dependency` (`PluginB` did not resolve embedded resources because it had no missing dependencies).

# Changes:

- Added a check to skip loading abstract `Plugin` types.
- The `AssemblyUtils` class has been modified to load an embedded resource only if no assembly with the same name has been loaded yet. This affects the methods `ResolveEmbeddedResources` `LoadEmbeddedDll` `LoadCompressedEmbeddedDll`
- Added a check to skip loading abstract `Plugin` types.
- After the plugin assemblies are loaded, the list of assemblies is iterated over:
  - Dependencies are checked, any embedded resource DLLs are extracted and loaded.
  - After all assemblies have been checked for dependencies, another loop loads the plugins.

This way, a plugin can reference dependencies that another plugin includes as embedded resources.