### PR TITLE
fix: add duplicate check if player is already registered

### DIFF
--- a/LabApi/Features/Wrappers/Players/Player.cs
+++ b/LabApi/Features/Wrappers/Players/Player.cs
@@ -1,4 +1,4 @@
-﻿using CentralAuth;
+using CentralAuth;
 using CommandSystem;
 using CustomPlayerEffects;
 using Footprinting;
@@ -1639,15 +1639,20 @@ public class Player
     /// <param name="referenceHub">The reference hub of the player.</param>
     private static void AddPlayer(ReferenceHub referenceHub)
     {
-        if (!referenceHub.isLocalPlayer)
-            _ = new Player(referenceHub);
-    }
+		if (referenceHub.isLocalPlayer)
+			return;
 
-    /// <summary>
-    /// Handles the removal of a player from the server.
-    /// </summary>
-    /// <param name="referenceHub">The reference hub of the player.</param>
-    private static void RemovePlayer(ReferenceHub referenceHub)
+		if (Dictionary.ContainsKey(referenceHub))
+			return;
+
+		_ = new Player(referenceHub);
+	}
+
+	/// <summary>
+	/// Handles the removal of a player from the server.
+	/// </summary>
+	/// <param name="referenceHub">The reference hub of the player.</param>
+	private static void RemovePlayer(ReferenceHub referenceHub)
     {
         if (referenceHub.authManager.UserId != null)
             UserIdCache.Remove(referenceHub.authManager.UserId);


### PR DESCRIPTION
This fixes the common error:

```
[2025-07-30 12:24:18.129 +03:00] [STDOUT] ArgumentException: An item with the same key has already been added. Key: ReferenceHub (Name='Player [connId=21]', NetID='9316', PlayerID='39')
[2025-07-30 12:24:18.130 +03:00] [STDOUT]   at System.Collections.Generic.Dictionary`2[TKey,TValue].TryInsert (TKey key, TValue value, System.Collections.Generic.InsertionBehavior behavior) [0x0015a] in <069d7b80a3914a08b6825aa362b07f5e>:0
[2025-07-30 12:24:18.130 +03:00] [STDOUT]   at System.Collections.Generic.Dictionary`2[TKey,TValue].Add (TKey key, TValue value) [0x00000] in <069d7b80a3914a08b6825aa362b07f5e>:0
[2025-07-30 12:24:18.130 +03:00] [STDOUT]   at LabApi.Features.Wrappers.Player..ctor (ReferenceHub referenceHub) [0x0000b] in <ed207da941d64f12942f0c5cc79632fc>:0
[2025-07-30 12:24:18.130 +03:00] [STDOUT]   at LabApi.Features.Wrappers.Player.AddPlayer (ReferenceHub referenceHub) [0x00008] in <ed207da941d64f12942f0c5cc79632fc>:0
[2025-07-30 12:24:18.130 +03:00] [STDOUT]   at (wrapper delegate-invoke) System.Action`1[ReferenceHub].invoke_void_T(ReferenceHub)
[2025-07-30 12:24:18.130 +03:00] [STDOUT]   at (wrapper dynamic-method) ReferenceHub.ReferenceHub.Start_Patch2(ReferenceHub)
```

by adding additional checks if the player is already in the directory.