### PR TITLE
Added a wrapper for map generation seed and helper functions to Map

### DIFF
--- a/LabApi/Features/Wrappers/Facility/Map.cs
+++ b/LabApi/Features/Wrappers/Facility/Map.cs
@@ -12,11 +12,6 @@ namespace LabApi.Features.Wrappers;
 public static class Map
 {
     /// <summary>
-    /// Gets the current seed of the map.
-    /// </summary>
-    public static int Seed => SeedSynchronizer.Seed;
-
-    /// <summary>
     /// Gets all the <see cref="Room">rooms</see>.
     /// </summary>
     public static IReadOnlyCollection<Room> Rooms => Room.List;
@@ -61,6 +56,44 @@ public static class Map
     /// </summary>
     public static IReadOnlyCollection<Ragdoll> Ragdolls => Ragdoll.List;
 
+    #region Seed
+    /// <summary>
+    /// Gets the current seed of the map.
+    /// </summary>
+    public static int Seed => SeedSynchronizer.Seed;
+
+    /// <summary>
+    /// Sets the seed for the next map generation.
+    /// This must be called before map generation starts.
+    /// </summary>
+    /// <param name="seed">The seed to use for map generation.</param>
+    /// <returns>True if the seed was set successfully, false if map generation has already started.</returns>
+    public static bool SetNextMapSeed(int seed) => MapSeed.SetNextMapSeed(seed);
+
+    /// <summary>
+    /// Gets the currently set pending seed.
+    /// </summary>
+    /// <returns>The pending seed if set, otherwise null.</returns>
+    public static int? GetPendingSeed() => MapSeed.GetPendingSeed();
+
+    /// <summary>
+    /// Clears the pending seed, allowing the game to use its default seed generation.
+    /// </summary>
+    public static void ClearPendingSeed() => MapSeed.ClearPendingSeed();
+
+    /// <summary>
+    /// Checks if a seed has been set for the next map generation.
+    /// </summary>
+    /// <returns>True if a seed is pending, false otherwise.</returns>
+    public static bool HasPendingSeed() => MapSeed.HasPendingSeed();
+
+    /// <summary>
+    /// Checks if the last set seed was successfully applied during map generation.
+    /// </summary>
+    /// <returns>True if the seed was applied, false otherwise.</returns>
+    public static bool WasSeedApplied() => MapSeed.WasSeedApplied();
+
+    #endregion
 
     #region Get Random
     /// <summary>

--- a/LabApi/Features/Wrappers/Facility/MapSeed.cs
+++ b/LabApi/Features/Wrappers/Facility/MapSeed.cs
@@ -1,0 +1,116 @@
+﻿using LabApi.Events.Handlers;
+using LabApi.Features.Console;
+using MapGeneration;
+using System;
+using Generators;
+using LabApi.Events.Arguments.ServerEvents;
+
+namespace LabApi.Features.Wrappers;
+
+/// <summary>
+/// Manages map seed setting and retrieval.
+/// </summary>
+public static class MapSeed
+{
+    private static int? _pendingSeed;
+    private static bool _seedSet = false;
+    private static bool _seedWasApplied = false;
+
+    /// <summary>
+    /// Initializes the MapSeedManager by subscribing to map generation events.
+    /// </summary>
+    [InitializeWrapper]
+    internal static void Initialize()
+    {
+        ServerEvents.MapGenerating += OnMapGenerating;
+        ServerEvents.MapGenerated += OnMapGenerated;
+    }
+
+    /// <summary>
+    /// Sets the seed for the next map generation.
+    /// This must be called before map generation starts.
+    /// </summary>
+    /// <param name="seed">The seed to use for map generation.</param>
+    /// <returns>True if the seed was set successfully, false if map generation has already started.</returns>
+    public static bool SetNextMapSeed(int seed)
+    {
+        if (seed < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(seed), "Seed value must be non-negative.");
+        }
+
+        if (_seedSet)
+        {
+            return false;
+        }
+
+        _pendingSeed = seed;
+        _seedWasApplied = false;
+        return true;
+    }
+
+    /// <summary>
+    /// Gets the currently set pending seed.
+    /// </summary>
+    /// <returns>The pending seed if set, otherwise null.</returns>
+    public static int? GetPendingSeed() => _pendingSeed;
+
+    /// <summary>
+    /// Clears the pending seed, allowing the game to use its default seed generation.
+    /// </summary>
+    public static void ClearPendingSeed()
+    {
+        _pendingSeed = null;
+        _seedWasApplied = false;
+    }
+
+    /// <summary>
+    /// Checks if a seed has been set for the next map generation.
+    /// </summary>
+    /// <returns>True if a seed is pending, false otherwise.</returns>
+    public static bool HasPendingSeed() => _pendingSeed.HasValue;
+
+    /// <summary>
+    /// Gets the current map seed.
+    /// </summary>
+    /// <returns>The current map seed.</returns>
+    public static int GetCurrentSeed() => SeedSynchronizer.Seed;
+
+    /// <summary>
+    /// Checks if the last set seed was successfully applied during map generation.
+    /// </summary>
+    /// <returns>True if the seed was applied, false otherwise.</returns>
+    public static bool WasSeedApplied() => _seedWasApplied;
+
+    private static void OnMapGenerating(MapGeneratingEventArgs ev)
+    {
+        try
+        {
+            if (_pendingSeed.HasValue)
+            {
+                ev.Seed = _pendingSeed.Value;
+                _seedSet = true;
+                _seedWasApplied = true;
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to apply pending seed during map generation: {ex.Message}", ex);
+        }
+    }
+
+    private static void OnMapGenerated(MapGeneratedEventArgs ev)
+    {
+        try
+        {
+            // Reset for next round
+            _pendingSeed = null;
+            _seedSet = false;
+            _seedWasApplied = false;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to reset seed state after map generation: {ex.Message}", ex);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces a new static `MapSeed` class and a corresponding region Seed section in the `Map` wrapper to support map generation using a custom-defined seed.

---

## Why should it be added?

Some server communities (particularly roleplay (RP) groups) benefit from repeatable and consistent map layouts. This change allows a server to define a map seed before the round starts, making sure that the same layout is generated every time that seed is used.

It is optional, does not interfere with random generation if unused, and resets automatically after use.

---

## What's New

### New Class: `MapSeed.cs`
- Handles the lifecycle and application of a user-defined seed.
- Subscribes to `ServerEvents.MapGenerating` and `ServerEvents.MapGenerated`.
- Ensures seeds are applied safely and reset after each round.

### Modifications to `Map.cs`
- Added a region for seed-related functionality to ease structure.
- Exposed the following public methods and properties:
  - `Map.Seed` → Gets the current map seed.
  - `Map.SetNextMapSeed(int seed)` → Sets the seed to use for the next map generation.
  - `Map.GetPendingSeed()` → Gets the pending seed if one is set.
  - `Map.ClearPendingSeed()` → Clears the current pending seed.
  - `Map.HasPendingSeed()` → Checks if a seed is set.
  - `Map.WasSeedApplied()` → Indicates if the pending seed was used in the last generation.

---