### PR TITLE
Adding extra reload-related getters + better CanReload check

### DIFF
--- a/LabApi/Features/Wrappers/Items/Firearm/FirearmItem.cs
+++ b/LabApi/Features/Wrappers/Items/Firearm/FirearmItem.cs
@@ -145,12 +145,12 @@ public class FirearmItem : Item
     /// <summary>
     /// Gets whether the player can reload this firearm.
     /// </summary>
-    public bool CanReload => IReloadUnloadValidatorModule.ValidateReload(Base);
+    public bool CanReload => IReloadUnloadValidatorModule.ValidateReload(Base) && !IsReloadingOrUnloading;
 
     /// <summary>
     /// Gets whether the player can unload this firearm.
     /// </summary>
-    public bool CanUnload => IReloadUnloadValidatorModule.ValidateUnload(Base);
+    public bool CanUnload => IReloadUnloadValidatorModule.ValidateUnload(Base) && !IsReloadingOrUnloading;
 
     /// <summary>
     /// Gets the firearm's ammo type.


### PR DESCRIPTION
This PR adds **IsReloading**, **IsUnloading** and **IsReloadingOrUnloading** getters to the LabApi **FirearmItem** wrapper.

It also adds a second change ensuring that **CanReload will only return true if the firearm isn't in use** (reload/unload) since base game would deny this reload. 
If this change is not wanted, I think CanReload should have it's description (or also the name) changed since it doesn't reflect what it does as it only checks if the Owner of the firearm has enough ammo to perform the reload.