### PR TITLE
Change IsUsing setter

### DIFF
--- a/LabApi/Features/Wrappers/Items/Usable/UsableItem.cs
+++ b/LabApi/Features/Wrappers/Items/Usable/UsableItem.cs
@@ -63,7 +63,9 @@ public class UsableItem : Item
     public bool IsUsing
     {
         get => Base.IsUsing;
-        set => Base.IsUsing = value;
+        set => UsableItemsController.ServerEmulateMessage(
+            Serial,
+            value ? StatusMessage.StatusType.Start : StatusMessage.StatusType.Cancel);
     }
 
     /// <summary>


### PR DESCRIPTION
Right now setter `IsUsing` setter does nothing. 
This pull request changes that so it makes the usable start / cancel use if in players hands