### PR TITLE
Predefined Plugin RequiredApiVersion

### DIFF
--- a/LabApi/Features/Wrappers/Facility/Respawning/Waves/RespawnWave.cs
+++ b/LabApi/Features/Wrappers/Facility/Respawning/Waves/RespawnWave.cs
@@ -106,7 +106,7 @@ public abstract class RespawnWave
     public float TimeLeft
     {
         get => Base.Timer.TimeLeft;
-        set => Base.Timer.SetTime(value);
+        set => Base.Timer.SetTime(Base.Timer.SpawnIntervalSeconds - value);
     }
 
     /// <summary>

--- a/LabApi/Features/Wrappers/Items/Usable/UsableItem.cs
+++ b/LabApi/Features/Wrappers/Items/Usable/UsableItem.cs
@@ -63,7 +63,9 @@ public class UsableItem : Item
     public bool IsUsing
     {
         get => Base.IsUsing;
-        set => Base.IsUsing = value;
+        set => UsableItemsController.ServerEmulateMessage(
+            Serial,
+            value ? StatusMessage.StatusType.Start : StatusMessage.StatusType.Cancel);
     }
 
     /// <summary>


### PR DESCRIPTION
Small change for consideration.

Usually a plugin is made for the LabAPI version it's built with. This can be found in the LabAPI plugin example as well https://github.com/northwood-studios/LabAPI/wiki/Writing-Your-First-Plugin.

Proposed change is to set the `Plugin#RequiredApiVersion` using `LabApiProperties.CompiledVersion` in the base class and change the member from `abstract` to `virtual`. This will still allow developers to change the version if they prefer, but will not be a required override.

It's 1 less boilerplate step for making new plugins.