### PR TITLE
Fix typo in DoorName enum

### DIFF
--- a/LabApi/Features/Enums/DoorName.cs
+++ b/LabApi/Features/Enums/DoorName.cs
@@ -33,7 +33,7 @@ public enum DoorName
     HczHidUpper, // HID_UPPER
     HczHidLower, // HID_LOWER
     HczNukeArmory, // NUKE_ARMORY
-    Hcz106Primiary, // 106_PRIMARY
+    Hcz106Primary, // 106_PRIMARY
     Hcz106Secondary, // 106_SECONDARY
     HczCheckpoint, // CHECKPOINT_EZ_HCZ_A
     Hcz127Lab, // HCZ_127_LAB


### PR DESCRIPTION
small change to the `DoorName` enum correcting a typo.

Hcz106Primiary --> Hcz106Primary