### PR TITLE
make Player::GameObject not nullable

### DIFF
--- a/LabApi/Features/Wrappers/Players/Player.cs
+++ b/LabApi/Features/Wrappers/Players/Player.cs
@@ -570,7 +570,8 @@ public class Player
     /// <summary>
     /// Gets the player's <see cref="GameObject"/>.
     /// </summary>
-    public GameObject? GameObject => ReferenceHub ? ReferenceHub.gameObject : null;
+    /// <remarks>Can be null if the <see cref="ReferenceHub"/> is null.</remarks>
+    public GameObject GameObject => ReferenceHub.gameObject;
 
     /// <summary>
     /// Gets whether the player is the host or server.


### PR DESCRIPTION
it should not be nullable in the first place just why it is. if GameObject should be nullable then ReferenceHub should be nullable and if the ReferenceHub is null then the whole Player is null i am losing my ming