### PR TITLE
PermissionsManager and DefaultPermissionsProvider improvements

### DIFF
--- a/LabApi/Features/Permissions/PermissionsManager.cs
+++ b/LabApi/Features/Permissions/PermissionsManager.cs
@@ -2,6 +2,7 @@ using LabApi.Features.Console;
 using LabApi.Features.Wrappers;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace LabApi.Features.Permissions;
@@ -31,13 +32,7 @@ public static class PermissionsManager
             return;
         }
 
-        if (Activator.CreateInstance<T>() is not IPermissionsProvider provider)
-        {
-            Logger.Error($"{LoggerPrefix} Failed to create an instance of the permission provider of type {typeof(T).FullName}.");
-            return;
-        }
-
-        PermissionProviders.Add(typeof(T), provider);
+        PermissionProviders.Add(typeof(T), new T());
     }
 
     /// <summary>
@@ -62,13 +57,38 @@ public static class PermissionsManager
     /// <returns>The registered <see cref="IPermissionsProvider"/> of the given type <typeparamref name="T"/>; otherwise, null.</returns>
     public static IPermissionsProvider? GetProvider<T>()
         where T : IPermissionsProvider, new()
+        => GetProvider(typeof(T));
+
+    /// <summary>
+    /// Retrieves the registered <see cref="IPermissionsProvider"/> of the given type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the permission provider to retrieve.</typeparam>
+    /// <returns>The registered <see cref="IPermissionsProvider"/> of the given type <typeparamref name="T"/>; otherwise, null.</returns>
+    public static bool TryGetProvider<T>([NotNullWhen(true)] out T? provider)
+        where T : class, IPermissionsProvider, new()
     {
-        if (PermissionProviders.TryGetValue(typeof(T), out IPermissionsProvider provider))
+        provider = GetProvider(typeof(T)) as T;
+        return provider != null;
+    }
+
+    /// <summary>
+    /// Retrieves the registered <see cref="IPermissionsProvider"/> of the given type <paramref name="providerType"/>.
+    /// </summary>
+    /// <param name="providerType">The type of the permission provider to retrieve.</param>
+    /// <returns>The registered <see cref="IPermissionsProvider"/> of the given type <paramref name="providerType"/>; otherwise, null.</returns>
+    public static IPermissionsProvider? GetProvider(Type providerType)
+    {
+        if (providerType == null)
+        {
+            throw new ArgumentNullException(nameof(providerType));
+        }
+
+        if (PermissionProviders.TryGetValue(providerType, out IPermissionsProvider provider))
         {
             return provider;
         }
 
-        Logger.Warn($"{LoggerPrefix} The permission provider of type {typeof(T).FullName} is not registered.");
+        Logger.Warn($"{LoggerPrefix} The permission provider of type {providerType.FullName} is not registered.");
         return null;
     }
 

--- a/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
+++ b/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
@@ -173,6 +173,7 @@ public class DefaultPermissionsProvider : IPermissionsProvider
     /// </remarks>
     public bool AddPermissionGroup(string groupName, PermissionGroup group, bool overrideExisting = false)
     {
+        group.IsRuntime = true;
         if (overrideExisting)
         {
             _permissionsDictionary[groupName] = group;
@@ -271,5 +272,5 @@ public class DefaultPermissionsProvider : IPermissionsProvider
         }
     }
 
-    private void SavePermissions() => File.WriteAllText(_permissions.FullName, YamlParser.Serializer.Serialize(_permissionsDictionary));
+    private void SavePermissions() => File.WriteAllText(_permissions.FullName, YamlParser.Serializer.Serialize(_permissionsDictionary.Where(kvp => !kvp.Value.IsRuntime).ToDictionary(kvp => kvp.Key, kvp => kvp.Value)));
 }

--- a/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
+++ b/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
@@ -5,6 +5,7 @@ using NorthwoodLib.Pools;
 using Serialization;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 
@@ -110,9 +111,36 @@ public class DefaultPermissionsProvider : IPermissionsProvider
     /// <inheritdoc />
     void IPermissionsProvider.ReloadPermissions() => ReloadPermissions();
 
-    private PermissionGroup GetPlayerGroup(Player player) => _permissionsDictionary.GetValueOrDefault(player.PermissionsGroupName ?? "default") ?? PermissionGroup.Default;
+    /// <summary>
+    /// Gets the <see cref="PermissionGroup"/> the player is a part of.
+    /// </summary>
+    /// <param name="player">The player whose <see cref="PermissionGroup"/> to find.</param>
+    /// <returns>The <see cref="PermissionGroup"/> the player is a part of, otherwise <see cref="PermissionGroup.Default"/>.</returns>
+    public PermissionGroup GetPlayerGroup(Player player) => GetPermissionGroup(player.PermissionsGroupName ?? "default");
 
-    private string[] GetPermissions(PermissionGroup group)
+    /// <summary>
+    /// Gets the <see cref="PermissionGroup"/> from a <see cref="UserGroup"/>'s registry name.
+    /// </summary>
+    /// <param name="groupName">A <see cref="UserGroup"/>'s registry name to find the <see cref="PermissionGroup"/> of.</param>
+    /// <returns>The <see cref="PermissionGroup"/> if one is defined, <see cref="PermissionGroup.Default"/> otherwise.</returns>
+    /// <remarks>The <paramref name="groupName"/> should be a key in <see cref="PermissionsHandler.Groups"/> and not necessarily the <see cref="UserGroup.Name"/> as they can differ.</remarks>
+    public PermissionGroup GetPermissionGroup(string groupName) => _permissionsDictionary.GetValueOrDefault(groupName) ?? PermissionGroup.Default;
+
+    /// <summary>
+    /// Tries to get the <see cref="PermissionGroup"/> from a <see cref="UserGroup"/>'s registry name.
+    /// </summary>
+    /// <param name="groupName">A <see cref="UserGroup"/>'s registry name to find the <see cref="PermissionGroup"/> of.</param>
+    /// <param name="permissionGroup">The found <see cref="PermissionGroup"/> when true, null otherwise.</param>
+    /// <returns>Whether a <see cref="PermissionGroup"/> with the registry name of <paramref name="groupName"/> was found.</returns>
+    /// <remarks>The <paramref name="groupName"/> should be a key in <see cref="PermissionsHandler.Groups"/> and not necessarily the <see cref="UserGroup.Name"/> as they can differ.</remarks>
+    public bool TryGetPermissionGroup(string groupName, [NotNullWhen(true)] out PermissionGroup? permissionGroup) => _permissionsDictionary.TryGetValue(groupName, out permissionGroup);
+
+    /// <summary>
+    /// Gets the <see cref="string"/>[] of permissions a <see cref="PermissionGroup"/> grants.
+    /// </summary>
+    /// <param name="group">The <see cref="PermissionGroup"/>, permissions of which will be returned.</param>
+    /// <returns>A <see cref="string"/> array of permission to this group grants.</returns>
+    public string[] GetPermissions(PermissionGroup group)
     {
         List<string> permissions = ListPool<string>.Shared.Rent();
 
@@ -131,6 +159,41 @@ public class DefaultPermissionsProvider : IPermissionsProvider
 
         return [.. permissions];
     }
+
+    /// <summary>
+    /// Adds a new permission group or overrides an existing permission group.
+    /// </summary>
+    /// <param name="groupName">The registry name of a permission group.</param>
+    /// <param name="group">The group to add.</param>
+    /// <param name="overrideExisting">Whether to override any existing group.</param>
+    /// <returns>Whether the group was successfully added, always true if <paramref name="overrideExisting"/> is true.</returns>
+    /// <remarks>
+    /// The <paramref name="groupName"/> is used to get permissions of a player using <see cref="Player.PermissionsGroupName"/>.
+    /// The <paramref name="groupName"/> can also be obtained from a <see cref="UserGroup"/>'s registry name.
+    /// </remarks>
+    public bool AddPermissionGroup(string groupName, PermissionGroup group, bool overrideExisting = false)
+    {
+        if (overrideExisting)
+        {
+            _permissionsDictionary[groupName] = group;
+            return true;
+        }
+
+        return _permissionsDictionary.TryAdd(groupName, group);
+    }
+
+    /// <summary>
+    /// Adds a new permission group or overrides an existing permission group.
+    /// </summary>
+    /// <param name="groupName">The registry name of a permission group.</param>
+    /// <param name="group">The group which was removed or null.</param>
+    /// <returns>Whether the group was found and removed successfully.</returns>
+    /// <remarks>
+    /// The <paramref name="groupName"/> is used to get permissions of a player using <see cref="Player.PermissionsGroupName"/>.
+    /// The <paramref name="groupName"/> can also be obtained from a <see cref="UserGroup"/>'s registry name.
+    /// </remarks>
+    public bool RemovePermissionGroup(string groupName, [NotNullWhen(true)] out PermissionGroup? group)
+        => _permissionsDictionary.Remove(groupName, out group);
 
     private bool HasPermission(PermissionGroup group, string permission)
     {

--- a/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
+++ b/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
@@ -136,7 +136,7 @@ public class DefaultPermissionsProvider : IPermissionsProvider
     public bool TryGetPermissionGroup(string groupName, [NotNullWhen(true)] out PermissionGroup? permissionGroup) => _permissionsDictionary.TryGetValue(groupName, out permissionGroup);
 
     /// <summary>
-    /// Gets the <see cref="string"/>[] of permissions a <see cref="PermissionGroup"/> grants.
+    /// Gets the <see cref="string"/> array of permissions a <see cref="PermissionGroup"/> grants.
     /// </summary>
     /// <param name="group">The <see cref="PermissionGroup"/>, permissions of which will be returned.</param>
     /// <returns>A <see cref="string"/> array of permission to this group grants.</returns>

--- a/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
+++ b/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
@@ -170,6 +170,8 @@ public class DefaultPermissionsProvider : IPermissionsProvider
     /// <remarks>
     /// The <paramref name="groupName"/> is used to get permissions of a player using <see cref="Player.PermissionsGroupName"/>.
     /// The <paramref name="groupName"/> can also be obtained from a <see cref="UserGroup"/>'s registry name.
+    /// WARNING: If used to remove a group which wasn't created at runtime it can cause a change to the <see cref="PermissionsFileName"/> file's contents.
+    /// WARNING: It marks all permission groups as Runtime, and as such when overriding a group it can cause it to be deleted if it was previously obtained from the <see cref="PermissionsFileName"/> file.
     /// </remarks>
     public bool AddPermissionGroup(string groupName, PermissionGroup group, bool overrideExisting = false)
     {
@@ -192,6 +194,7 @@ public class DefaultPermissionsProvider : IPermissionsProvider
     /// <remarks>
     /// The <paramref name="groupName"/> is used to get permissions of a player using <see cref="Player.PermissionsGroupName"/>.
     /// The <paramref name="groupName"/> can also be obtained from a <see cref="UserGroup"/>'s registry name.
+    /// WARNING: If used to remove a group which wasn't created at runtime it can cause a change to the <see cref="PermissionsFileName"/> file's contents.
     /// </remarks>
     public bool RemovePermissionGroup(string groupName, [NotNullWhen(true)] out PermissionGroup? group)
         => _permissionsDictionary.Remove(groupName, out group);

--- a/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
+++ b/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
@@ -119,27 +119,25 @@ public class DefaultPermissionsProvider : IPermissionsProvider
     public PermissionGroup GetPlayerGroup(Player player) => GetPermissionGroup(player.PermissionsGroupName ?? "default");
 
     /// <summary>
-    /// Gets the <see cref="PermissionGroup"/> from a <see cref="UserGroup"/>'s registry name.
+    /// Gets the <see cref="PermissionGroup"/> from a <see cref="UserGroup.Name"/>.
     /// </summary>
-    /// <param name="groupName">A <see cref="UserGroup"/>'s registry name to find the <see cref="PermissionGroup"/> of.</param>
-    /// <returns>The <see cref="PermissionGroup"/> if one is defined, <see cref="PermissionGroup.Default"/> otherwise.</returns>
-    /// <remarks>The <paramref name="groupName"/> should be a key in <see cref="PermissionsHandler.Groups"/> and not necessarily the <see cref="UserGroup.Name"/> as they can differ.</remarks>
+    /// <param name="groupName">A <see cref="UserGroup.Name"/> to find the <see cref="PermissionGroup"/> of.</param>
+    /// <returns>A <see cref="PermissionGroup"/> if one is defined, <see cref="PermissionGroup.Default"/> otherwise.</returns>
     public PermissionGroup GetPermissionGroup(string groupName) => _permissionsDictionary.GetValueOrDefault(groupName) ?? PermissionGroup.Default;
 
     /// <summary>
-    /// Tries to get the <see cref="PermissionGroup"/> from a <see cref="UserGroup"/>'s registry name.
+    /// Tries to get the <see cref="PermissionGroup"/> from a <see cref="UserGroup.Name"/>.
     /// </summary>
-    /// <param name="groupName">A <see cref="UserGroup"/>'s registry name to find the <see cref="PermissionGroup"/> of.</param>
+    /// <param name="groupName">A <see cref="UserGroup.Name"/> to find the <see cref="PermissionGroup"/> of.</param>
     /// <param name="permissionGroup">The found <see cref="PermissionGroup"/> when true, null otherwise.</param>
     /// <returns>Whether a <see cref="PermissionGroup"/> with the registry name of <paramref name="groupName"/> was found.</returns>
-    /// <remarks>The <paramref name="groupName"/> should be a key in <see cref="PermissionsHandler.Groups"/> and not necessarily the <see cref="UserGroup.Name"/> as they can differ.</remarks>
     public bool TryGetPermissionGroup(string groupName, [NotNullWhen(true)] out PermissionGroup? permissionGroup) => _permissionsDictionary.TryGetValue(groupName, out permissionGroup);
 
     /// <summary>
     /// Gets the <see cref="string"/> array of permissions a <see cref="PermissionGroup"/> grants.
     /// </summary>
     /// <param name="group">The <see cref="PermissionGroup"/>, permissions of which will be returned.</param>
-    /// <returns>A <see cref="string"/> array of permission to this group grants.</returns>
+    /// <returns>A <see cref="string"/> array of permissions this group grants.</returns>
     public string[] GetPermissions(PermissionGroup group)
     {
         List<string> permissions = ListPool<string>.Shared.Rent();
@@ -161,43 +159,34 @@ public class DefaultPermissionsProvider : IPermissionsProvider
     }
 
     /// <summary>
-    /// Adds a new permission group or overrides an existing permission group.
+    /// Adds a new permission group.
     /// </summary>
-    /// <param name="groupName">The registry name of a permission group.</param>
+    /// <param name="groupName">A <see cref="UserGroup.Name"/> the <paramref name="group"/> is linked to.</param>
     /// <param name="group">The group to add.</param>
-    /// <param name="overrideExisting">Whether to override any existing group.</param>
-    /// <returns>Whether the group was successfully added, always true if <paramref name="overrideExisting"/> is true.</returns>
-    /// <remarks>
-    /// The <paramref name="groupName"/> is used to get permissions of a player using <see cref="Player.PermissionsGroupName"/>.
-    /// The <paramref name="groupName"/> can also be obtained from a <see cref="UserGroup"/>'s registry name.
-    /// WARNING: If used to remove a group which wasn't created at runtime it can cause a change to the <see cref="PermissionsFileName"/> file's contents.
-    /// WARNING: It marks all permission groups as Runtime, and as such when overriding a group it can cause it to be deleted if it was previously obtained from the <see cref="PermissionsFileName"/> file.
-    /// </remarks>
-    public bool AddPermissionGroup(string groupName, PermissionGroup group, bool overrideExisting = false)
-    {
-        group.IsRuntime = true;
-        if (overrideExisting)
-        {
-            _permissionsDictionary[groupName] = group;
-            return true;
-        }
-
-        return _permissionsDictionary.TryAdd(groupName, group);
-    }
+    /// <returns>Whether the group was successfully added. False if group with this name is already registered or if the <paramref name="group"/>'s <see cref="PermissionGroup.IsRuntime"/> is set to false.</returns>
+    public bool AddPermissionGroup(string groupName, PermissionGroup group)
+        => group.IsRuntime && _permissionsDictionary.TryAdd(groupName, group);
 
     /// <summary>
-    /// Adds a new permission group or overrides an existing permission group.
+    /// Removes a permission group if it exists.
     /// </summary>
-    /// <param name="groupName">The registry name of a permission group.</param>
+    /// <param name="groupName">A <see cref="UserGroup.Name"/> which links to a <see cref="PermissionGroup"/> that is to be removed.</param>
     /// <param name="group">The group which was removed or null.</param>
-    /// <returns>Whether the group was found and removed successfully.</returns>
-    /// <remarks>
-    /// The <paramref name="groupName"/> is used to get permissions of a player using <see cref="Player.PermissionsGroupName"/>.
-    /// The <paramref name="groupName"/> can also be obtained from a <see cref="UserGroup"/>'s registry name.
-    /// WARNING: If used to remove a group which wasn't created at runtime it can cause a change to the <see cref="PermissionsFileName"/> file's contents.
-    /// </remarks>
+    /// <returns>Whether the group was found and removed successfully. False if group with this name could not be found or if the <paramref name="group"/>'s <see cref="PermissionGroup.IsRuntime"/> is set to false.</returns>
     public bool RemovePermissionGroup(string groupName, [NotNullWhen(true)] out PermissionGroup? group)
-        => _permissionsDictionary.Remove(groupName, out group);
+    {
+        if (!_permissionsDictionary.TryGetValue(groupName, out group))
+        {
+            return false;
+        }
+
+        if (!group.IsRuntime)
+        {
+            return false;
+        }
+
+        return _permissionsDictionary.Remove(groupName, out group);
+    }
 
     private bool HasPermission(PermissionGroup group, string permission)
     {

--- a/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
+++ b/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
@@ -47,6 +47,10 @@ public class DefaultPermissionsProvider : IPermissionsProvider
         {
             // We deserialize the permissions from the file.
             _permissionsDictionary = YamlParser.Deserializer.Deserialize<Dictionary<string, PermissionGroup>>(File.ReadAllText(_permissions.FullName));
+            foreach (PermissionGroup permissionGroup in _permissionsDictionary.Values)
+            {
+                permissionGroup.IsRuntime = false;
+            }
 
             // We then reload the permissions to fill the special permissions.
             ReloadPermissions();

--- a/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
+++ b/LabApi/Features/Permissions/Providers/DefaultPermissionsProvider.cs
@@ -47,10 +47,6 @@ public class DefaultPermissionsProvider : IPermissionsProvider
         {
             // We deserialize the permissions from the file.
             _permissionsDictionary = YamlParser.Deserializer.Deserialize<Dictionary<string, PermissionGroup>>(File.ReadAllText(_permissions.FullName));
-            foreach (PermissionGroup permissionGroup in _permissionsDictionary.Values)
-            {
-                permissionGroup.IsRuntime = false;
-            }
 
             // We then reload the permissions to fill the special permissions.
             ReloadPermissions();

--- a/LabApi/Features/Permissions/Providers/PermissionGroup.cs
+++ b/LabApi/Features/Permissions/Providers/PermissionGroup.cs
@@ -11,7 +11,7 @@ public class PermissionGroup
     /// <summary>
     /// Gets the default permission group.
     /// </summary>
-    public static PermissionGroup Default => new([], []);
+    public static PermissionGroup Default => new([], []) { IsRuntime = false };
 
     /// <summary>
     /// Generates the default permission groups based on the available groups in the RA settings.
@@ -68,7 +68,7 @@ public class PermissionGroup
     /// An internal bool indicating whether the permission was created at runtime and should not be saved.
     /// </summary>
     [YamlIgnore]
-    internal bool IsRuntime { get; set; } = false;
+    public bool IsRuntime { get; internal set; } = true;
 
     /// <summary>
     /// An internal dictionary that saves special permissions. (x.*).

--- a/LabApi/Features/Permissions/Providers/PermissionGroup.cs
+++ b/LabApi/Features/Permissions/Providers/PermissionGroup.cs
@@ -65,6 +65,12 @@ public class PermissionGroup
     public bool IsRoot { get; set; } = false;
 
     /// <summary>
+    /// An internal bool indicating whether the permission was created at runtime and as such should not be saved.
+    /// </summary>
+    [YamlIgnore]
+    internal bool IsRuntime { get; set; } = false;
+
+    /// <summary>
     /// An internal dictionary that saves special permissions. (x.*).
     /// </summary>
     [YamlIgnore]

--- a/LabApi/Features/Permissions/Providers/PermissionGroup.cs
+++ b/LabApi/Features/Permissions/Providers/PermissionGroup.cs
@@ -65,7 +65,7 @@ public class PermissionGroup
     public bool IsRoot { get; set; } = false;
 
     /// <summary>
-    /// An internal bool indicating whether the permission was created at runtime and as such should not be saved.
+    /// An internal bool indicating whether the permission was created at runtime and should not be saved.
     /// </summary>
     [YamlIgnore]
     internal bool IsRuntime { get; set; } = false;

--- a/LabApi/Features/Permissions/Providers/PermissionGroup.cs
+++ b/LabApi/Features/Permissions/Providers/PermissionGroup.cs
@@ -32,8 +32,11 @@ public class PermissionGroup
     /// <summary>
     /// Constructor for deserialization.
     /// </summary>
+    /// <remarks>
+    /// All objects created by this constructor will have their <see cref="IsRuntime"/> property set to false.
+    /// </remarks>
     public PermissionGroup()
-        : this([], [])
+        : this([], [], false)
     {
     }
 
@@ -42,10 +45,12 @@ public class PermissionGroup
     /// </summary>
     /// <param name="inheritedGroups">Array of groups that should be inherited.</param>
     /// <param name="permissions">Array of permissions this group should have.</param>
-    public PermissionGroup(string[] inheritedGroups, string[] permissions)
+    /// <param name="isRuntime">Bool indicating whether the <see cref="PermissionGroup"/> should skip being saved to the permission file config. See: <seealso cref="IsRuntime"/>.</param>
+    public PermissionGroup(string[] inheritedGroups, string[] permissions, bool isRuntime = true)
     {
         InheritedGroups = inheritedGroups;
         Permissions = permissions;
+        IsRuntime = isRuntime;
     }
 
     /// <summary>
@@ -65,10 +70,11 @@ public class PermissionGroup
     public bool IsRoot { get; set; } = false;
 
     /// <summary>
-    /// An internal bool indicating whether the permission was created at runtime and should not be saved.
+    /// A bool indicating whether the permission was created at runtime and should not be saved.
+    /// Will not be saved if set to true.
     /// </summary>
     [YamlIgnore]
-    public bool IsRuntime { get; internal set; } = true;
+    public bool IsRuntime { get; internal set; }
 
     /// <summary>
     /// An internal dictionary that saves special permissions. (x.*).


### PR DESCRIPTION
Provides new methods which can be used to interact with the PermissionManager and DefaultPermissionsProvider in more ways without the need for publicizing the assembly.

This PR was made because of a suggestion: #424 

The changes made to the **PermissionManager** are mostly QoL with 1 exception.
List of changes:
- `RegisterProvider<T>` using `Activator.CreateInstance` even though the type argument was specified as supporting a parameterless constructor. Modified code so instead of using `Activator.CreateInstance<T>()` it uses `new T()`.
- `GetProvider(Type type)` which allows to get a provider even if we only have it's type object (runtime) as provided by `GetPermissionsByProvider`
- `TryGetProvider<T>(out provider) -> T` which allows the caller to automatically have the returned type be the type provided as an argument. 

The changes made to the **DefaultPermissionsProvider** allow for more interaction concerning obtainging full lists of permissions provided by a _UserGroup_ and allowing for runtime registration of .
List of changes:
- `RegisterProvider<T>` using `Activator.CreateInstance` even though the type argument was specified as supporting a parameterless constructor. Modified code so instead of using `Activator.CreateInstance<T>()` it uses `new T()`.
- `GetProvider(Type type)` which allows to get a provider even if we only have it's type object (runtime) as provided by `GetPermissionsByProvider`
- `TryGetProvider<T>(out provider) -> T` which allows the caller to automatically have the returned type be the type provided as an argument. 
- `GetPlayerGroup` was made public
- `GetPermissionGroup` was added to allow the caller obtain the `PermissionGroup` based on a string _UserGroup_ registry name.
- `GetPermissions` was made public
- `AddPermissionGroup` was added to allow the caller to add / override existing groups. 
- `RemovePermissionGroup` same reason as AddPermissionGroup` but for removal of groups.